### PR TITLE
feature: add support to install on Ubuntu 16.10 (yakkety)

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -20,11 +20,8 @@
 
     - name: install php7.0
       apt: name=php7.0-cli state=present 
-      when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'xenial'
-        
-    - name: install php7.0
-      apt: name=php7.0-cli state=present 
-      when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'yakkety'
+      when: ansible_distribution == 'Ubuntu' and 
+        (ansible_distribution_release == 'xenial' or ansible_distribution_release == 'yakkety')
         
     - file: src=/usr/bin/nodejs dest=/usr/local/bin/node state=link
 

--- a/dev.yml
+++ b/dev.yml
@@ -22,6 +22,10 @@
       apt: name=php7.0-cli state=present 
       when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'xenial'
         
+    - name: install php7.0
+      apt: name=php7.0-cli state=present 
+      when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'yakkety'
+        
     - file: src=/usr/bin/nodejs dest=/usr/local/bin/node state=link
 
     - name: install Composer


### PR DESCRIPTION
Hi Chris (or other folks). I used to be in Sentani, but I'm now working for a research lab stateside. I hope to go back overseas someday, but thought I'd put in a few pull requests on some of the non-C# stuff during Christmas break.

This change adds support for  Ubuntu 16.10 (yakkety yak). I just copied the block for xenial and told it to do the same for 'yakkety'.

After doing this, the script installed Composer and bower without error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/ops-devbox/2)
<!-- Reviewable:end -->
